### PR TITLE
Handle anonymous giving and receiving more gracefully than showing $NULL

### DIFF
--- a/chrome/websites/twitter/twitter.js
+++ b/chrome/websites/twitter/twitter.js
@@ -44,6 +44,16 @@
                     widget = widget.replace('{{USERNAME}}', username);
 
                     $('#gittip').html(widget);
+
+                    if (gittip.giving && gittip.receiving)
+                        $('#gittip .giving-receiving').show();
+                    else if (gittip.giving)
+                        $('#gittip .giving').show();
+                    else if (gittip.receiving)
+                        $('#gittip .receiving').show();
+                    else
+                        $('#gittip .neither').show();
+
                     $('.loading').hide();
                     $('.loaded').show();
                 },

--- a/chrome/websites/twitter/widget.html
+++ b/chrome/websites/twitter/widget.html
@@ -13,6 +13,22 @@
                 <div class="number">${{RECEIVE}}</div>
                 <div class="unit pad-sign">per week, and gives $<span class="total-giving">{{GIVING}}</span></div>
             </div>
+
+            <div class="giving">
+                <h2 class="pad-sign"><a href="https://www.gittip.com/on/twitter/{{USERNAME}}">{{USERNAME}}</a> gives</h2>
+                <div class="number">${{GIVING}}</div>
+                <div class="unit pad-sign">per week</div>
+            </div>
+
+            <div class="receiving">
+                <h2 class="pad-sign"><a href="https://www.gittip.com/on/twitter/{{USERNAME}}">{{USERNAME}}</a> receives</h2>
+                <div class="number">${{RECEIVE}}</div>
+                <div class="unit pad-sign">per week</div>
+            </div>
+
+            <div class="neither">
+                <h2 class="pad-sign"><a href="https://www.gittip.com/on/twitter/{{USERNAME}}">{{USERNAME}}</a> is quietly watching the Gittip world</h2>
+            </div>
         </div>
     </div>
 </div>
@@ -40,5 +56,9 @@
 }
 .total-giving {
     font-weight: bold;
+}
+
+.giving-receiving, .giving, .receiving, .neither {
+    display: none;
 }
 </style>


### PR DESCRIPTION
I split it up into multiple `<div>`s because it became a scary HTML-monster otherwise.
# Screenshots
## Public giving/public receiving

![01-public-giving-public-receiving](https://cloud.githubusercontent.com/assets/39698/2762454/4880ab2c-c9f1-11e3-9564-d5ddaedfa558.png)
## Public giving/anonymous receiving

![02-public-giving-anonymous-receiving](https://cloud.githubusercontent.com/assets/39698/2762460/5958c402-c9f1-11e3-81df-16300013b512.png)
## Anonymous giving/public receiving

![03-anonymous-giving-public-receiving](https://cloud.githubusercontent.com/assets/39698/2762462/65831b10-c9f1-11e3-9358-85181704bb18.png)
## Anonymous giving/anonymous receiving

![04-anonymous-giving-anonymous-receiving](https://cloud.githubusercontent.com/assets/39698/2762464/6c566410-c9f1-11e3-8b42-c82d10ea9176.png)
